### PR TITLE
Add build configuration for DDMM metadata

### DIFF
--- a/game/options.rpy
+++ b/game/options.rpy
@@ -171,6 +171,9 @@ init python:
 
     # stuff not in archive
     build.classify('README.html',build.name)
+    
+    # Doki Doki Mod Manager metadata file
+    build.classify('ddmm-mod.json',build.name)
 
     # mark as documentation
     build.documentation('README.html')


### PR DESCRIPTION
This PR allows the `ddmm-mod.json` file to be included in the mod distribution. This file allows mod authors to include metadata with their mod, such as a name, authors and version numbers.

Although you could manually add this file after the build process, it'd be easier for mod authors to have the ability to have it included in the build process.

Note this feature is not yet available in current versions of DDMM, but it is coming soon™.

See: DokiDokiModManager/Mod-Manager#41